### PR TITLE
Updated CONTRIBUTING.md template-tool file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,3 +36,4 @@ To ensure reproducability of results and software, a default docker file is incl
 A step-by-step guide to getting started also included in the following [video](https://www.youtube.com/watch?v=oO8n3y23b6M). 
 
 ## Workflow
+Workflow for both internal and external lab members outlined in the [NDClab contributing wiki doc](https://ndclab.github.io/wiki/docs/contributing.html). 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,18 @@
-# Outline 
+# Contributing to [project name]
+
+## Overview
+Please note our general guidelines for contributing to NDCLab projects [here](https://ndclab.github.io/wiki/docs/contributing.html).
 
 * [Roadmap](#Roadmap)  
-    * [Overview](#Overview)
-    * [Structure](#Directory-Structure)
-    * [Function-Standards](#Function-Standards)
-* [Containers](#Containers)
-* [Git-Workflow](#Git-Workflow)  
-* [CI-test](#CI-test)  
-* [Reminders](#Reminders)  
-
+* [Directory-Structure](#Directory-Structure)  
+* [Scripts](#Scripts)
+* [Containers](#Containers)  
+* [Workflow](#Workflow)  
 
 ## Roadmap
+Please see the roadmap available on the README.md file of this repository.
 
-### Overview 
-
-### Directory-Structure
+## Directory-Structure
 ```yml
 baseEEG
 ├── run.py
@@ -32,44 +30,9 @@ The `scripts` directory is where Python modules will be pulled from. This ensure
 
 More info on creating packages [here](https://docs.python.org/3/tutorial/modules.html#packages). 
 
-## Container
+## Containers
 To ensure reproducability of results and software, a default docker file is included with this template repository. The respective [README.md](#container/README.md) contains a comprehensive guide on how to get started with containerization (special thanks to [Jonhas](https://github.com/Jonhas))!
 
 A step-by-step guide to getting started also included in the following [video](https://www.youtube.com/watch?v=oO8n3y23b6M). 
 
-### Function-Standards 
-
-
-## Containers
-
-## Git-Workflow 
-
-![ndcworkflow](https://user-images.githubusercontent.com/26397102/116148813-00512800-a6a7-11eb-9624-cd81f11d3ada.png)
-
-Development is driven by the [feature branch workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow), where each new feature is encapsulated in a branch. This ensures changes are properly tested & integrated while still allowing for development to be done in parallel.
-
-Subsequently, branches follow this convention:
-
-`main`
-- 100% stable and usable by any lab members.
-- *No direct commits*
-
-`->dev`
-- Up to date development branch with properly tested/reviewed features. 
-- *No direct commits*
-
-`-->dev-feature-[featureName]`
-- Ongoing development and testing of feature to be pull requested into `dev`.
-
-`--->dev-feature-[featureName]-[yourName]`
-- *Only* branch available for personal development, must be branched off of `-->dev-feature-[featureName]` branch.
-- Merged into `-->dev-feature-[featureName]` after pull-request.
-
-To ensure branch cleanliness, be sure to enable automatic deletion of branches! To do this hover over to "Settings" and scroll down to the "Automatically delete head branches" option and select the checkbox. 
-
-![image](https://user-images.githubusercontent.com/26397102/123699167-f1b0f980-d82c-11eb-9d6e-b9c24d952401.png)
-
-## CI-test
-
-
-## Reminders
+## Workflow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Please note our general guidelines for contributing to NDCLab projects [here](ht
 * [Workflow](#Workflow)  
 
 ## Roadmap
-Please see the roadmap available on the [README.md](https://github.com/NDCLab/template-tool/blob/main/README.md) file of this repository.
+Please see the roadmap available on the [README.md](https://github.com/NDCLab/template-tool/blob/main/container/README.md) file of this repository.
 
 ## Directory Structure
 ```yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Please note our general guidelines for contributing to NDCLab projects [here](ht
 * [Workflow](#Workflow)  
 
 ## Roadmap
-Please see the roadmap available on the [README.md](https://github.com/NDCLab/template-tool/blob/main/container/README.md) file of this repository.
+Please see the roadmap available on the [README.md](https://github.com/NDCLab/template-tool/blob/main/README.md) file of this repository.
 
 :point_right: Keep the "Roadmap" text above but update the link to the `readme` for your repo. And, of course, delete this note before publishing the contributing file.
 
@@ -31,7 +31,7 @@ project-name
 The `scripts` directory is the local [package](https://docs.python.org/3/tutorial/modules.html#packages) where Python modules will be written. This ensures that modules are neatly divided according to responsibility, which helps with parallel development and debugging. 
 
 ### Container
-To ensure reproducibility of results and software, a default docker file is included with this template repository. The respective [README.md](https://github.com/NDCLab/template-tool/blob/main/README.md) contains a comprehensive guide on how to get started with containerization (special thanks to [Jonhas](https://github.com/Jonhas))!
+To ensure reproducibility of results and software, a default docker file is included with this template repository. The respective [README.md](https://github.com/NDCLab/template-tool/tree/main/container) contains a comprehensive guide on how to get started with containerization (special thanks to [Jonhas](https://github.com/Jonhas))!
 
 A step-by-step guide to getting started also included in the following [video](https://www.youtube.com/watch?v=oO8n3y23b6M). 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,11 @@ Please note our general guidelines for contributing to NDCLab projects [here](ht
 * [Workflow](#Workflow)  
 
 ## Roadmap
-Please see the roadmap available on the README.md file of this repository.
+Please see the roadmap available on the [README.md](https://github.com/NDCLab/template-tool/blob/main/README.md) file of this repository.
 
-## Directory-Structure
+## Directory Structure
 ```yml
-baseEEG
+project-name
 ├── run.py
 ├── scripts
 |    ├──__init__.py
@@ -25,13 +25,11 @@ baseEEG
 ├── .github 
 ```
 
-## Scripts
-The `scripts` directory is where Python modules will be pulled from. This ensures that modules are neatly divided according to responsibility, which helps with parallel development and debugging. 
+### Scripts
+The `scripts` directory is the local [package](https://docs.python.org/3/tutorial/modules.html#packages) where Python modules will be written in. This ensures that modules are neatly divided according to responsibility, which helps with parallel development and debugging. 
 
-More info on creating packages [here](https://docs.python.org/3/tutorial/modules.html#packages). 
-
-## Containers
-To ensure reproducability of results and software, a default docker file is included with this template repository. The respective [README.md](#container/README.md) contains a comprehensive guide on how to get started with containerization (special thanks to [Jonhas](https://github.com/Jonhas))!
+### Containers
+To ensure reproducibility of results and software, a default docker file is included with this template repository. The respective [README.md](https://github.com/NDCLab/template-tool/blob/main/README.md) contains a comprehensive guide on how to get started with containerization (special thanks to [Jonhas](https://github.com/Jonhas))!
 
 A step-by-step guide to getting started also included in the following [video](https://www.youtube.com/watch?v=oO8n3y23b6M). 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,15 @@
 Please note our general guidelines for contributing to NDCLab projects [here](https://ndclab.github.io/wiki/docs/contributing.html).
 
 * [Roadmap](#Roadmap)  
-* [Directory-Structure](#Directory-Structure)  
+* [Directory Structure](#Directory-Structure)  
 * [Scripts](#Scripts)
 * [Containers](#Containers)  
 * [Workflow](#Workflow)  
 
 ## Roadmap
 Please see the roadmap available on the [README.md](https://github.com/NDCLab/template-tool/blob/main/README.md) file of this repository.
+
+:point_right: Keep the "Roadmap" text above but update the link to the `readme` for your repo. And, of course, delete this note before publishing the contributing file.
 
 ## Directory Structure
 ```yml
@@ -26,12 +28,12 @@ project-name
 ```
 
 ### Scripts
-The `scripts` directory is the local [package](https://docs.python.org/3/tutorial/modules.html#packages) where Python modules will be written in. This ensures that modules are neatly divided according to responsibility, which helps with parallel development and debugging. 
+The `scripts` directory is the local [package](https://docs.python.org/3/tutorial/modules.html#packages) where Python modules will be written. This ensures that modules are neatly divided according to responsibility, which helps with parallel development and debugging. 
 
-### Containers
+### Container
 To ensure reproducibility of results and software, a default docker file is included with this template repository. The respective [README.md](https://github.com/NDCLab/template-tool/blob/main/README.md) contains a comprehensive guide on how to get started with containerization (special thanks to [Jonhas](https://github.com/Jonhas))!
 
 A step-by-step guide to getting started also included in the following [video](https://www.youtube.com/watch?v=oO8n3y23b6M). 
 
 ## Workflow
-Workflow for both internal and external lab members outlined in the [NDClab contributing wiki doc](https://ndclab.github.io/wiki/docs/contributing.html). 
+Workflow for both internal and external lab members is outlined on the [NDCLab contributing wiki page](https://ndclab.github.io/wiki/docs/contributing.html). 


### PR DESCRIPTION
- populated containers section
- integrated outline & directory details 
- linked [contributing wiki doc](https://ndclab.github.io/wiki/docs/contributing.html) for workflow since it already comprehensively details the workflow for both internal and external members. 